### PR TITLE
Prevented use of empty SKID's

### DIFF
--- a/apps/x509.c
+++ b/apps/x509.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 1995-2024 The OpenSSL Project Authors. All Rights Reserved.
+ * Copyright 1995-2025 The OpenSSL Project Authors. All Rights Reserved.
  *
  * Licensed under the Apache License 2.0 (the "License").  You may not use
  * this file except in compliance with the License.  You can obtain a copy
@@ -792,6 +792,35 @@ int x509_main(int argc, char **argv)
         x = load_cert_pass(infile, informat, 1, passin, "certificate");
         if (x == NULL)
             goto end;
+        /* Force SKID presence check */
+        fprintf(stderr, "debug: x509 main 2\n");
+        fflush(stdout);
+        int skid_index;
+        X509_EXTENSION* skid_ext;
+        ASN1_OCTET_STRING* skid_value;
+
+        /* Check if SKID exists */
+        skid_index = X509_get_ext_by_NID(x, NID_subject_key_identifier, -1);
+        if (skid_index == -1) {
+            BIO_printf(bio_err, 
+                "Error: Subject Key Identifier (SKID) is missing in the certificate.\n");
+            goto err;
+        }
+
+        /* Retrieve the SKID extension */
+        skid_ext = X509_get_ext(x, skid_index);
+        if (skid_ext == NULL) {
+            BIO_printf(bio_err, 
+                "Error: Failed to retrieve Subject Key Identifier (SKID) extension.\n");
+            goto err;
+        }
+
+        /* Get the actual SKID value */
+        skid_value = X509V3_EXT_d2i(skid_ext);
+        if (skid_value == NULL || ASN1_STRING_length(skid_value) == 0) {
+            BIO_printf(bio_err, "Error: Subject Key Identifier (SKID) is empty.\n");
+            goto err;
+        }
     }
     if ((fsubj != NULL || req != NULL)
         && !X509_set_subject_name(x, fsubj != NULL ? fsubj :


### PR DESCRIPTION
It is a more scuffed solution to ensure empty or invalid SKID's are not used, fixing a part of the main function. 
Attached is the CERT used for testing.

[Cert1732784126935D1.zip](https://github.com/user-attachments/files/19140111/Cert1732784126935D1.zip)

Related issue: 26088.

